### PR TITLE
Install urdf_parser_py from ros2 branch to support utf8 encoded urdf files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
 pycollada  # to load .dae files
-urdfdom-py @ git+https://github.com/ros/urdf_parser_py.git@1.2.1
+urdfdom-py @ git+https://github.com/ros/urdf_parser_py.git@ros2
 pyyaml  # dependency for urdf_parser_py (see package.xml)
 lxml  # dependency for urdf_parser_py (see package.xml)
 pillow


### PR DESCRIPTION
This was fixed in https://github.com/ros/urdf_parser_py/commit/7ca2810717eca40426b126296c06aaae5604fd7f but there is no released version with this fix yet.