### PR TITLE
Raise warning if a visual could not be loaded

### DIFF
--- a/src/rerun_loader_python_example_urdf/__init__.py
+++ b/src/rerun_loader_python_example_urdf/__init__.py
@@ -93,6 +93,8 @@ class URDFLogger:
             mesh_or_scene = trimesh.load_mesh(resolved_path)
             if mesh_scale is not None:
                 transform[:3, :3] *= mesh_scale
+            else:
+                print(f"Warning: Could not load {resolved_path}")
         elif isinstance(visual.geometry, urdf_parser.Box):
             mesh_or_scene = trimesh.creation.box(extents=visual.geometry.size)
         elif isinstance(visual.geometry, urdf_parser.Cylinder):


### PR DESCRIPTION
Currently loading an urdf that fails silently fails.