### PR TITLE
Prefer logging `Asset3D` over trimesh when possible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "rerun-loader-urdf"
 description = "Example of an executable data-loader plugin for the Rerun Viewer for URDF files."
-version = "0.2.0"
+version = "0.3.0"
 requires-python = ">=3.10"
 dependencies = [
   "urdfdom-py",

--- a/src/rerun_loader_urdf/__init__.py
+++ b/src/rerun_loader_urdf/__init__.py
@@ -114,6 +114,10 @@ class URDFLogger:
             transform = rr.Transform3D(scale=mesh_scale)
 
             recording.log(entity_path + f"/{resolved_path}", rr.Asset3D(path=resolved_path), transform)
+            if material is not None:
+                recording.log(
+                    entity_path + f"/{resolved_path}", rr.Asset3D.from_fields(albedo_factor=material.color.rgba)
+                )
 
         elif isinstance(visual.geometry, urdf_parser.Box):
             mesh_or_scene = trimesh.creation.box(extents=visual.geometry.size)


### PR DESCRIPTION
### What

This now logs an `rr.Asset3D` instead of a mesh when possible. This retains the normals of the original mesh without trimesh smoothing them out.

This currently depends on the latest Rerun main (rerun-io/rerun#9997) for better STL loading