### PR TITLE
Accept unknown args as this make this module future proof against fut…

### DIFF
--- a/src/rerun_loader_urdf/__init__.py
+++ b/src/rerun_loader_urdf/__init__.py
@@ -306,7 +306,7 @@ def main() -> None:
         action="append",
         help="optional sequences to log at (e.g. `--sequence sim_frame=42`)",
     )
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
 
     is_file = os.path.isfile(args.filepath)
     is_urdf_file = any(ext in args.filepath for ext in [".urdf", ".xacro"])


### PR DESCRIPTION
…ure unknown args

It seems that rerun 0.23 introduces new args for module which are not supported here

```bash
error: unrecognized arguments: --time_sequence log_tick=0 --time_duration_nanos log_time=1748347179402113908
```

This makes it possible to have the code at the very least resilient to new argument